### PR TITLE
Made data a public part of phi

### DIFF
--- a/code/arcaders-1-6/src/phi/mod.rs
+++ b/code/arcaders-1-6/src/phi/mod.rs
@@ -1,7 +1,7 @@
 use ::sdl2::render::Renderer;
 use ::sdl2::timer;
 
-mod data;
+pub mod data;
 
 #[macro_use]
 mod events;


### PR DESCRIPTION
I couldn't compile unless the `data` module was public.

Thanks for this project btw, it's working fine on OSX apart from that.
