### PR TITLE
x and y need to be of type f64

### DIFF
--- a/_posts/2015-07-25-arcaders-1-6.md
+++ b/_posts/2015-07-25-arcaders-1-6.md
@@ -445,8 +445,8 @@ directly over the call to `move_inside`.
 //
 // We restrain the width because most screens are wider than they are high.
 let movable_region = Rectangle {
-    x: 0,
-    y: 0,
+    x: 0.0,
+    y: 0.0,
     w: phi.output_size().0 as f64 * 0.70,
     h: phi.output_size().1 as f64,
 };


### PR DESCRIPTION
Rust gets angry otherwise:
    src\views/mod.rs:75:10: 75:11 error: mismatched types:
     expected `f64`,
        found `_`
    (expected f64,
        found integral variable) [E0308]
    src\views/mod.rs:75       x: 0,
                                 ^
    src\views/mod.rs:75:10: 75:11 help: run `rustc --explain E0308` to see a detailed explanation
    src\views/mod.rs:76:10: 76:11 error: mismatched types:
     expected `f64`,
        found `_`
    (expected f64,
        found integral variable) [E0308]
    src\views/mod.rs:76       y: 0,
                                 ^
    src\views/mod.rs:76:10: 76:11 help: run `rustc --explain E0308` to see a detailed explanation
