### PR TITLE
include call to to use SDL2 Renderer

### DIFF
--- a/_posts/2015-10-26-arcaders-1-8.md
+++ b/_posts/2015-10-26-arcaders-1-8.md
@@ -157,6 +157,10 @@ We would like our background to move at the same _logical velocity_ no matter
 the size of the screen. To do so...
 
 ```rust
+use sdl2::render::Renderer;
+
+//? ...
+
 impl Background {
     fn render(&mut self, renderer: &mut Renderer, elapsed: f64) {
         // We define a logical position as depending solely on the time and the


### PR DESCRIPTION
I got an error when compiling complaining that there was no Renderer type.

I hadn't looked at the code for ages and had forgotten the previous exact call for the library; I couldn't find it on the page and had to look on the github codebase to find it.
