### PR TITLE
add reminder to include dev libraries

### DIFF
--- a/_posts/2015-10-26-arcaders-1-7.md
+++ b/_posts/2015-10-26-arcaders-1-7.md
@@ -47,6 +47,9 @@ sdl2 = "0.13"
 sdl2_image = "1.0.0"
 ```
 
+Make sure that you have downloaded and appropriately placed the necessary
+[development libraries](https://www.libsdl.org/projects/SDL_image/), as with SDL2.
+
 Akin to SDL2, this library must be initialized. And, like SDL2, it also relies
 on a context object to clean up behind itself. As such, we can simply include
 the `sdl2_image` crate in the `main.rs` file:


### PR DESCRIPTION
As a newbie to SDL, gcc and rust libraries, I stumbled over not doing any more than explicitly described in the text.

I didn't download the necessary files and got the note at the end of a long error message from gcc "note: ld: cannot find -lSDL2_image". It took me a while to realise that a library was missing and how to fix it.

This is clearly due to my inexperience, but there may well be similarly inexperienced people following the series.
