### PR TITLE
Fix some errors in 1.2

### DIFF
--- a/_posts/2015-10-17-arcaders-1-2.md
+++ b/_posts/2015-10-17-arcaders-1-2.md
@@ -403,11 +403,11 @@ use events::Events;
 
 fn main() {
     // Initialize SDL2
-    let mut sdl_context = sdl2::init().video()
-        .build().unwrap();
+    let sdl_context = sdl2::init().unwrap();
+    let video = sdl_context.video().unwrap();
 
     // Create the window
-    let window = sdl_context.window("ArcadeRS Shooter", 800, 600)
+    let window = video.window("ArcadeRS Shooter", 800, 600)
         .position_centered().opengl()
         .build().unwrap();
 
@@ -415,7 +415,7 @@ fn main() {
         .accelerated()
         .build().unwrap();
 
-    let mut events = Events::new(sdl_context.event_pump());
+    let mut events = Events::new(sdl_context.event_pump().unwrap());
 
     loop {
         events.pump();


### PR DESCRIPTION
I'm loving the series. Thank you for writing it!

The changes here match the 1.2 snapshot code. Also, there's this line that seems outdated or incorrect:

> We also have to make sdl_context mutable so that the EventPump can poll events from it behind the scene.
