### PR TITLE
remove incorrect casts in 1-6 Rectangle helpers

### DIFF
--- a/_posts/2015-10-18-arcaders-1-6.md
+++ b/_posts/2015-10-18-arcaders-1-6.md
@@ -531,21 +531,21 @@ impl Rectangle {
 
     pub fn contains(&self, rect: Rectangle) -> bool {
         let xmin = rect.x;
-        let xmax = xmin + rect.w as i32;
+        let xmax = xmin + rect.w;
         let ymin = rect.y;
-        let ymax = ymin + rect.h as i32;
+        let ymax = ymin + rect.h;
 
-        xmin >= self.x && xmin <= self.x + self.w as i32 &&
-        xmax >= self.x && xmax <= self.x + self.w as i32 &&
-        ymin >= self.y && ymin <= self.y + self.h as i32 &&
-        ymax >= self.y && ymax <= self.y + self.h as i32
+        xmin >= self.x && xmin <= self.x + self.w &&
+        xmax >= self.x && xmax <= self.x + self.w &&
+        ymin >= self.y && ymin <= self.y + self.h &&
+        ymax >= self.y && ymax <= self.y + self.h
     }
 
     pub fn overlaps(&self, other: Rectangle) -> bool {
-        self.x < other.x + other.w as i32 &&
-        self.x + self.w as i32 > other.x &&
-        self.y < other.y + other.h as i32 &&
-        self.y + self.h as i32 > other.y
+        self.x < other.x + other.w &&
+        self.x + self.w > other.x &&
+        self.y < other.y + other.h &&
+        self.y + self.h > other.y
     }
 }
 ```


### PR DESCRIPTION
Looks like 1-6 has some outdated code for the Rectangle helpers that prevents it from compiling.

Thanks for the wonderful tutorial!
