### PR TITLE
ArcadeRS: Update tutorials for sdl2 0.24 stack

### DIFF
--- a/_posts/2015-10-17-arcaders-1-0.md
+++ b/_posts/2015-10-17-arcaders-1-0.md
@@ -8,6 +8,7 @@ categories: arcaders
 > 2015-07-25: Changed library to rust-sdl2 0.6, no change to rust code.  
 > 2015-10-17: Changed library to rust-sdl2 0.9; increased the date of publication.  
 > 2016-01-21: Changed library to rust-sdl2 0.13, minimal change to rust code.
+> 2016-10-22: Changed library to rust-sdl2 0.24, minimal change to rust code.
 
 
 This is the introduction of a series whose objective is to explore the Rust
@@ -66,7 +67,7 @@ required by 2D games, such as _views_ (called _screens_ in LibGDX), _rectangles_
 with built-in (albeit basic) collision detection, and _animated sprites_.
 
 The libraries we are going to use for that will be AngryLawyer's SDL2 bindings,
-version 0.13, which you can see [here](https://github.com/AngryLawyer/rust-sdl2),
+version 0.24, which you can see [here](https://github.com/AngryLawyer/rust-sdl2),
 and the associated plugins.
 
 Before we continue, I want to stress that you do not need to have mastered Rust

--- a/_posts/2015-10-17-arcaders-1-1.md
+++ b/_posts/2015-10-17-arcaders-1-1.md
@@ -27,7 +27,7 @@ configuration file in order to include some dependencies. You should add the
 following lines at the end of the file:
 
     [dependencies]
-    sdl2 = "0.13"
+    sdl2 = "0.24"
 
 Towards the end, our project will depend on _way_ more external _crates_
 (Rust's concept of a library), but this is all we need for the moment. The

--- a/_posts/2015-10-18-arcaders-1-6.md
+++ b/_posts/2015-10-18-arcaders-1-6.md
@@ -110,9 +110,7 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 }
 ```
@@ -143,9 +141,7 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 }
 
@@ -188,7 +184,7 @@ impl View for ShipView {
 
         // Render the scene
         phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-        phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
 
         ViewAction::None
     }
@@ -475,9 +471,7 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
     /// Returns a (perhaps moved) rectangle which is contained by a `parent`

--- a/_posts/2015-10-26-arcaders-1-7.md
+++ b/_posts/2015-10-26-arcaders-1-7.md
@@ -22,8 +22,8 @@ change your `Cargo.toml` file so that you have the following dependencies:
 
 ```
 [dependencies]
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
+sdl2 = "0.24"
+sdl2_image = "0.24"
 ```
 
 Make sure that you have downloaded and appropriately placed the necessary
@@ -319,7 +319,7 @@ Now, for _rendering_ the image (in `ShipView::render`):
 //? This was previously there:
 // Render the bounding box (for debugging purposes)
 phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
 
 //? We add this part:
 // Render the ship
@@ -335,7 +335,8 @@ phi.renderer.copy(&mut self.player.tex,
     }.to_sdl(),
     //? The destination of the image. We simply provide the bounding box, the
     //? renderer takes care of the rest.
-    self.player.rect.to_sdl());
+    self.player.rect.to_sdl())
+    .unwrap();
 ```
 
 ![The spritesheet and its bounding box](/images/arcade-8.png)
@@ -358,7 +359,8 @@ phi.renderer.copy(&mut self.player.tex,
         w: self.player.rect.w,
         h: self.player.rect.h,
     }.to_sdl(),
-    self.player.rect.to_sdl());
+    self.player.rect.to_sdl())
+    .unwrap();
 ```
 
 Assuming, of course, that the bounding box `player.rect` now has a width of 43
@@ -398,7 +400,8 @@ phi.renderer.copy(&mut self.player.tex,
         w: self.player.rect.w,
         h: self.player.rect.h,
     }.to_sdl(),
-    self.player.rect.to_sdl());
+    self.player.rect.to_sdl())
+    .unwrap();
 ```
 
 ![Only one frame of the ship](/images/arcade-9.png)
@@ -565,7 +568,7 @@ impl Sprite {
     // ...
 
     pub fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 ```

--- a/_posts/2015-10-26-arcaders-1-8.md
+++ b/_posts/2015-10-26-arcaders-1-8.md
@@ -115,7 +115,7 @@ self.bg_middle.render(&mut phi.renderer, elapsed);
 // Render the bounding box (for debugging purposes)
 if DEBUG {
     phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-    phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+    phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
 }
 
 // Render the ship

--- a/_posts/2015-10-30-arcaders-1-9.md
+++ b/_posts/2015-10-30-arcaders-1-9.md
@@ -19,27 +19,24 @@ Let's modify our `Cargo.toml` file's dependencies once more:
 
 ```
 [dependencies]
-sdl2 = "0.13"
-sdl2_image = "0.3"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_ttf = "0.24"
 ```
 
 The way in which we initialize this plugin is pretty standard: the `init` function
-returns a handler which takes care of cleaning everything. As such, in
-`phi/mod.rs`, we have:
+returns a handler which takes care of cleaning everything:
 
 ```rust
-// Initialize SDL2
-let sdl_context = ::sdl2::init().unwrap();
-let video = sdl_context.video().unwrap();
-let mut timer = sdl_context.timer().unwrap();
-let _image_context = ::sdl2_image::init(::sdl2_image::INIT_PNG).unwrap();
-let _ttf_context = ::sdl2_ttf::init().unwrap();
+let ttf_context = ::sdl2_ttf::init().unwrap();
 ```
 
-We can now use it. Because we are about to have a many-views project, though,
-let's move the content of `views/mod.rs` into a new file `views/game.rs` and
-change the content of the (now empty) `views/mod.rs` file to:
+And we could now use it. But before that, let's setup the structure of our main
+menu view where the sdl2_ttf dependency will be used.
+
+As we are about to have a many-views project, we'll move the content of
+`views/mod.rs` into a new file `views/game.rs` and change the content of the
+`(now empty) `views/mod.rs` file to:
 
 ```rust
 pub mod game;
@@ -135,12 +132,15 @@ The next part is to generate those sprites from a label. To render text, we must
 go through the following procedure:
 
 ```rust
+// Initialize TTF context
+let ttf_context = ::sdl2_ttf::init().unwrap();
+
 // Load the font from a file
-let font = ::sdl2_ttf::Font::from_file(Path::new(font_path), size).unwrap();
+let font = ttf_context.load_font(Path::new(font_path), size as u16).unwrap();
 
 // For historical reasons, we must first render the text as a `Surface`
 // (a purely 2D image).
-let surface = font.render(text, ::sdl2_ttf::blended(color)).unwrap()
+let surface = font.render(text).blended(color).unwrap()
 
 // Then, we turn this image into a `Texture`, which is more efficient.
 let texture = self.renderer.create_texture_from_surface(&surface).unwrap();
@@ -149,14 +149,44 @@ let texture = self.renderer.create_texture_from_surface(&surface).unwrap();
 let sprite = Sprite::new(texture);
 ```
 
-That's a lot of things to do every time, and we're still not correctly handling
-the possibility of any step failing. So we're going to add a utility function to
-`Phi` (it will become clear why soon enough):
+As we need to have access to the TTF context to load new font files, we'll add
+the one spawned with the window to the Phi struct, and instance it directly in
+the constructor:
+
+```rust
+use sdl2_ttf::Sdl2TtfContext;
+
+//? ...
+
+pub struct Phi<'window> {
+    pub events: Events,
+    pub renderer: Renderer<'window>,
+
+    ttf_context: Sdl2TtfContext,
+}
+
+impl<'window> Phi<'window> {
+    fn new(events: Events, renderer: Renderer<'window>) -> Phi<'window> {
+        Phi {
+            events: events,
+            renderer: renderer,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
+        }
+    }
+
+    //? ...
+}
+```
+
+The above-described procedure is a lot of things to do every time, and we're
+still not correctly handling the possibility of any step failing. So we're going
+to add a utility function to `Phi` (it will become clear why soon enough).
 
 ```rust
 use self::gfx::Sprite;
 use sdl2::render::Renderer;
 use sdl2::pixels::Color;
+use sdl2_ttf::Sdl2TtfContext;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -167,7 +197,7 @@ impl<'window> Phi<'window> {
 
     pub fn ttf_str_sprite(&mut self, text: &str, font_path: &'static str, size: i32, color: Color) -> Option<Sprite> {
         //? We start by trying to load the requested font.
-        ::sdl2_ttf::Font::from_file(Path::new(font_path), size).ok()
+        self.ttf_context.load_font(Path::new(font_path), size).ok()
             //? We must wrap the next steps in a closure because borrow checker.
             //? More precisely, `font` must live at least until the texture is
             //? created.
@@ -216,6 +246,7 @@ pub struct Phi<'window> {
     pub events: Events,
     pub renderer: Renderer<'window>,
 
+    ttf_context: Sdl2TtfContext,
     cached_fonts: HashMap<(&'static str, i32), ::sdl2_ttf::Font>,
 }
 
@@ -224,6 +255,7 @@ impl<'window> Phi<'window> {
         Phi {
             events: events,
             renderer: renderer,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
             cached_fonts: HashMap::new(),
         }
     }
@@ -249,7 +281,7 @@ impl<'window> Phi<'window> {
         }
 
         //? Otherwise, we start by trying to load the requested font.
-        ::sdl2_ttf::Font::from_file(Path::new(font_path), size).ok()
+        self.ttf_context.load_font(Path::new(font_path), size).ok()
             .and_then(|font| {
                 //? If this works, we cache the font we acquired.
                 self.cached_fonts.insert((font_path, size), font);
@@ -496,7 +528,8 @@ phi.renderer.fill_rect(Rectangle {
     h: box_h + border_width * 2.0 + margin_h * 2.0,
     x: (win_w - box_w) / 2.0 - border_width,
     y: (win_h - box_h) / 2.0 - margin_h - border_width,
-}.to_sdl().unwrap());
+}.to_sdl().unwrap())
+.unwrap();
 
 // Render the colored box which holds the labels
 phi.renderer.set_draw_color(Color::RGB(140, 30, 140));
@@ -505,7 +538,8 @@ phi.renderer.fill_rect(Rectangle {
     h: box_h + margin_h * 2.0,
     x: (win_w - box_w) / 2.0,
     y: (win_h - box_h) / 2.0 - margin_h,
-}.to_sdl().unwrap());
+}.to_sdl().unwrap())
+.unwrap();
 
 // Render the labels in the menu
 for (i, action) in self.actions.iter().enumerate() {

--- a/_posts/2015-12-08-arcaders-1-10.md
+++ b/_posts/2015-12-08-arcaders-1-10.md
@@ -158,7 +158,7 @@ block. Do not forget to remove them from the already-existing `impl` blocks.
 ```rust
 impl Renderable for Sprite {
     fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/_posts/2016-01-03-arcaders-1-11.md
+++ b/_posts/2016-01-03-arcaders-1-11.md
@@ -68,7 +68,7 @@ impl RectBullet {
         //? This is exactly how we drew our first moving rectangle in the
         //? seventh part of this series.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
     }
 
     /// Return the bullet's bounding box.
@@ -467,7 +467,7 @@ impl Bullet for RectBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -846,7 +846,7 @@ impl Bullet for SineBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -1007,7 +1007,7 @@ impl Bullet for DivergentBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {

--- a/_posts/2016-01-16-arcaders-1-12.md
+++ b/_posts/2016-01-16-arcaders-1-12.md
@@ -74,7 +74,7 @@ impl Asteroid {
         if DEBUG {
             // Render the bounding box
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+            phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
         }
 
         phi.renderer.copy_sprite(&self.sprite, self.rect);
@@ -1052,7 +1052,7 @@ impl Player {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the ship's current sprite.

--- a/_posts/2016-03-22-arcaders-1-13.md
+++ b/_posts/2016-03-22-arcaders-1-13.md
@@ -31,10 +31,10 @@ First, let's add this library to our `Cargo.toml` dependencies:
 ```
 [dependencies]
 rand = "0.3"
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
-sdl2_mixer = "0.12"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_mixer = "0.24"
+sdl2_ttf = "0.24"
 ```
 
 Then, let's import it in `main.rs`:
@@ -319,6 +319,7 @@ pub struct Phi<'window> {
     pub renderer: Renderer<'window>,
 
     allocated_channels: isize,
+    ttf_context: Sdl2TtfContext,
     cached_fonts: HashMap<(&'static str, i32), ::sdl2_ttf::Font>,
 }
 
@@ -332,6 +333,7 @@ impl<'window> Phi<'window> {
             events: events,
             renderer: renderer,
             allocated_channels: allocated_channels,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
             cached_fonts: HashMap::new(),
         }
     }

--- a/code/arcaders-1-1/Cargo.toml
+++ b/code/arcaders-1-1/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
+sdl2 = "0.24"

--- a/code/arcaders-1-10/Cargo.toml
+++ b/code/arcaders-1-10/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
 rand = "0.3"
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_ttf = "0.24"

--- a/code/arcaders-1-10/src/phi/data.rs
+++ b/code/arcaders-1-10/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
         // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
 

--- a/code/arcaders-1-10/src/phi/gfx.rs
+++ b/code/arcaders-1-10/src/phi/gfx.rs
@@ -74,7 +74,7 @@ impl Sprite {
 
 impl Renderable for Sprite {
     fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-10/src/phi/mod.rs
+++ b/code/arcaders-1-10/src/phi/mod.rs
@@ -6,6 +6,7 @@ pub mod gfx;
 use self::gfx::Sprite;
 use sdl2::render::Renderer;
 use sdl2::pixels::Color;
+use sdl2_ttf::Sdl2TtfContext;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -32,6 +33,7 @@ pub struct Phi<'window> {
     pub events: Events,
     pub renderer: Renderer<'window>,
 
+    ttf_context: Sdl2TtfContext,
     cached_fonts: HashMap<(&'static str, i32), ::sdl2_ttf::Font>,
 }
 
@@ -40,6 +42,7 @@ impl<'window> Phi<'window> {
         Phi {
             events: events,
             renderer: renderer,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
             cached_fonts: HashMap::new(),
         }
     }
@@ -53,12 +56,12 @@ impl<'window> Phi<'window> {
     /// Renders a string of text as a sprite using the provided parameters.
     pub fn ttf_str_sprite(&mut self, text: &str, font_path: &'static str, size: i32, color: Color) -> Option<Sprite> {
         if let Some(font) = self.cached_fonts.get(&(font_path, size)) {
-            return font.render(text, ::sdl2_ttf::blended(color)).ok()
+            return font.render(text).blended(color).ok()
                 .and_then(|surface| self.renderer.create_texture_from_surface(&surface).ok())
                 .map(Sprite::new)
         }
 
-        ::sdl2_ttf::Font::from_file(Path::new(font_path), size).ok()
+        self.ttf_context.load_font(Path::new(font_path), size as u16).ok()
             .and_then(|font| {
                 self.cached_fonts.insert((font_path, size), font);
                 self.ttf_str_sprite(text, font_path, size, color)
@@ -122,7 +125,6 @@ where F: Fn(&mut Phi) -> Box<View> {
     let video = sdl_context.video().unwrap();
     let mut timer = sdl_context.timer().unwrap();
     let _image_context = ::sdl2_image::init(::sdl2_image::INIT_PNG).unwrap();
-    let _ttf_context = ::sdl2_ttf::init().unwrap();
 
     // Create the window
     let window = video.window(title, 800, 600)

--- a/code/arcaders-1-10/src/views/game.rs
+++ b/code/arcaders-1-10/src/views/game.rs
@@ -2,7 +2,6 @@ use phi::{Phi, View, ViewAction};
 use phi::data::Rectangle;
 use phi::gfx::{AnimatedSprite, CopySprite, Sprite};
 use sdl2::pixels::Color;
-use sdl2::render::Renderer;
 use views::shared::BgSet;
 
 
@@ -259,7 +258,7 @@ impl View for ShipView {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the ship

--- a/code/arcaders-1-10/src/views/main_menu.rs
+++ b/code/arcaders-1-10/src/views/main_menu.rs
@@ -115,7 +115,8 @@ impl View for MainMenuView {
             h: box_h + border_width * 2.0 + margin_h * 2.0,
             x: (win_w - box_w) / 2.0 - border_width,
             y: (win_h - box_h) / 2.0 - margin_h - border_width,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the colored box which holds the labels
         phi.renderer.set_draw_color(Color::RGB(140, 30, 140));
@@ -124,7 +125,8 @@ impl View for MainMenuView {
             h: box_h + margin_h * 2.0,
             x: (win_w - box_w) / 2.0,
             y: (win_h - box_h) / 2.0 - margin_h,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the labels in the menu
         for (i, action) in self.actions.iter().enumerate() {

--- a/code/arcaders-1-11/Cargo.toml
+++ b/code/arcaders-1-11/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
 rand = "0.3"
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_ttf = "0.24"

--- a/code/arcaders-1-11/src/phi/data.rs
+++ b/code/arcaders-1-11/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
         // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
 

--- a/code/arcaders-1-11/src/phi/gfx.rs
+++ b/code/arcaders-1-11/src/phi/gfx.rs
@@ -74,7 +74,7 @@ impl Sprite {
 
 impl Renderable for Sprite {
     fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-11/src/phi/mod.rs
+++ b/code/arcaders-1-11/src/phi/mod.rs
@@ -6,6 +6,7 @@ pub mod gfx;
 use self::gfx::Sprite;
 use sdl2::render::Renderer;
 use sdl2::pixels::Color;
+use sdl2_ttf::Sdl2TtfContext;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -36,6 +37,7 @@ pub struct Phi<'window> {
     pub events: Events,
     pub renderer: Renderer<'window>,
 
+    ttf_context: Sdl2TtfContext,
     cached_fonts: HashMap<(&'static str, i32), ::sdl2_ttf::Font>,
 }
 
@@ -44,6 +46,7 @@ impl<'window> Phi<'window> {
         Phi {
             events: events,
             renderer: renderer,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
             cached_fonts: HashMap::new(),
         }
     }
@@ -57,12 +60,12 @@ impl<'window> Phi<'window> {
     /// Renders a string of text as a sprite using the provided parameters.
     pub fn ttf_str_sprite(&mut self, text: &str, font_path: &'static str, size: i32, color: Color) -> Option<Sprite> {
         if let Some(font) = self.cached_fonts.get(&(font_path, size)) {
-            return font.render(text, ::sdl2_ttf::blended(color)).ok()
+            return font.render(text).blended(color).ok()
                 .and_then(|surface| self.renderer.create_texture_from_surface(&surface).ok())
                 .map(Sprite::new)
         }
 
-        ::sdl2_ttf::Font::from_file(Path::new(font_path), size).ok()
+        self.ttf_context.load_font(Path::new(font_path), size as u16).ok()
             .and_then(|font| {
                 self.cached_fonts.insert((font_path, size), font);
                 self.ttf_str_sprite(text, font_path, size, color)
@@ -126,7 +129,6 @@ where F: Fn(&mut Phi) -> Box<View> {
     let video = sdl_context.video().unwrap();
     let mut timer = sdl_context.timer().unwrap();
     let _image_context = ::sdl2_image::init(::sdl2_image::INIT_PNG).unwrap();
-    let _ttf_context = ::sdl2_ttf::init().unwrap();
 
     // Create the window
     let window = video.window(title, 800, 600)

--- a/code/arcaders-1-11/src/views/game.rs
+++ b/code/arcaders-1-11/src/views/game.rs
@@ -2,7 +2,6 @@ use phi::{Phi, View, ViewAction};
 use phi::data::Rectangle;
 use phi::gfx::{AnimatedSprite, CopySprite, Sprite};
 use sdl2::pixels::Color;
-use sdl2::render::Renderer;
 use views::shared::BgSet;
 
 
@@ -144,19 +143,6 @@ struct RectBullet {
     rect: Rectangle,
 }
 
-impl RectBullet {
-    fn new(x: f64, y: f64) -> RectBullet {
-        RectBullet {
-            rect: Rectangle {
-                x: x,
-                y: y,
-                w: BULLET_W,
-                h: BULLET_H,
-            }
-        }
-    }
-}
-
 impl Bullet for RectBullet {
     fn update(mut self: Box<Self>, phi: &mut Phi, dt: f64) -> Option<Box<Bullet>> {
         let (w, _) = phi.output_size();
@@ -173,7 +159,7 @@ impl Bullet for RectBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -208,7 +194,7 @@ impl Bullet for SineBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -253,7 +239,7 @@ impl Bullet for DivergentBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -507,13 +493,14 @@ impl View for ShipView {
         self.asteroid.update(phi, elapsed);
 
         // TODO: Detect collisions
-        
+
         // Allow the player to shoot after the bullets are updated, so that,
         // when rendered for the first time, they are drawn wherever they
         // spawned.
         if phi.events.now.key_space == Some(true) {
-        self.bullets.append(&mut self.player.spawn_bullets());
+            self.bullets.append(&mut self.player.spawn_bullets());
         }
+
 
         // Clear the scene
         phi.renderer.set_draw_color(Color::RGB(0, 0, 0));
@@ -526,7 +513,7 @@ impl View for ShipView {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the ship

--- a/code/arcaders-1-11/src/views/main_menu.rs
+++ b/code/arcaders-1-11/src/views/main_menu.rs
@@ -115,7 +115,8 @@ impl View for MainMenuView {
             h: box_h + border_width * 2.0 + margin_h * 2.0,
             x: (win_w - box_w) / 2.0 - border_width,
             y: (win_h - box_h) / 2.0 - margin_h - border_width,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the colored box which holds the labels
         phi.renderer.set_draw_color(Color::RGB(140, 30, 140));
@@ -124,7 +125,8 @@ impl View for MainMenuView {
             h: box_h + margin_h * 2.0,
             x: (win_w - box_w) / 2.0,
             y: (win_h - box_h) / 2.0 - margin_h,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the labels in the menu
         for (i, action) in self.actions.iter().enumerate() {

--- a/code/arcaders-1-12-preclean/Cargo.toml
+++ b/code/arcaders-1-12-preclean/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
 rand = "0.3"
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_ttf = "0.24"

--- a/code/arcaders-1-12-preclean/src/phi/data.rs
+++ b/code/arcaders-1-12-preclean/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
         // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
     /// Generate a rectangle with the provided size, with its top-left corner

--- a/code/arcaders-1-12-preclean/src/phi/gfx.rs
+++ b/code/arcaders-1-12-preclean/src/phi/gfx.rs
@@ -75,7 +75,7 @@ impl Sprite {
 
 impl Renderable for Sprite {
     fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-12-preclean/src/phi/mod.rs
+++ b/code/arcaders-1-12-preclean/src/phi/mod.rs
@@ -6,6 +6,7 @@ pub mod gfx;
 use self::gfx::Sprite;
 use sdl2::render::Renderer;
 use sdl2::pixels::Color;
+use sdl2_ttf::Sdl2TtfContext;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -36,6 +37,7 @@ pub struct Phi<'window> {
     pub events: Events,
     pub renderer: Renderer<'window>,
 
+    ttf_context: Sdl2TtfContext,
     cached_fonts: HashMap<(&'static str, i32), ::sdl2_ttf::Font>,
 }
 
@@ -44,6 +46,7 @@ impl<'window> Phi<'window> {
         Phi {
             events: events,
             renderer: renderer,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
             cached_fonts: HashMap::new(),
         }
     }
@@ -57,12 +60,12 @@ impl<'window> Phi<'window> {
     /// Renders a string of text as a sprite using the provided parameters.
     pub fn ttf_str_sprite(&mut self, text: &str, font_path: &'static str, size: i32, color: Color) -> Option<Sprite> {
         if let Some(font) = self.cached_fonts.get(&(font_path, size)) {
-            return font.render(text, ::sdl2_ttf::blended(color)).ok()
+            return font.render(text).blended(color).ok()
                 .and_then(|surface| self.renderer.create_texture_from_surface(&surface).ok())
                 .map(Sprite::new)
         }
 
-        ::sdl2_ttf::Font::from_file(Path::new(font_path), size).ok()
+        self.ttf_context.load_font(Path::new(font_path), size as u16).ok()
             .and_then(|font| {
                 self.cached_fonts.insert((font_path, size), font);
                 self.ttf_str_sprite(text, font_path, size, color)
@@ -126,7 +129,6 @@ where F: Fn(&mut Phi) -> Box<View> {
     let video = sdl_context.video().unwrap();
     let mut timer = sdl_context.timer().unwrap();
     let _image_context = ::sdl2_image::init(::sdl2_image::INIT_PNG).unwrap();
-    let _ttf_context = ::sdl2_ttf::init().unwrap();
 
     // Create the window
     let window = video.window(title, 800, 600)

--- a/code/arcaders-1-12-preclean/src/views/game.rs
+++ b/code/arcaders-1-12-preclean/src/views/game.rs
@@ -180,7 +180,7 @@ impl Bullet for RectBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -215,7 +215,7 @@ impl Bullet for SineBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -260,7 +260,7 @@ impl Bullet for DivergentBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -313,7 +313,7 @@ impl Asteroid {
     fn render(&self, phi: &mut Phi) {
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+            phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
         }
 
         phi.renderer.copy_sprite(&self.sprite, self.rect);
@@ -671,7 +671,7 @@ impl View for GameView {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the entities

--- a/code/arcaders-1-12-preclean/src/views/main_menu.rs
+++ b/code/arcaders-1-12-preclean/src/views/main_menu.rs
@@ -115,7 +115,8 @@ impl View for MainMenuView {
             h: box_h + border_width * 2.0 + margin_h * 2.0,
             x: (win_w - box_w) / 2.0 - border_width,
             y: (win_h - box_h) / 2.0 - margin_h - border_width,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the colored box which holds the labels
         phi.renderer.set_draw_color(Color::RGB(140, 30, 140));
@@ -124,7 +125,8 @@ impl View for MainMenuView {
             h: box_h + margin_h * 2.0,
             x: (win_w - box_w) / 2.0,
             y: (win_h - box_h) / 2.0 - margin_h,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the labels in the menu
         for (i, action) in self.actions.iter().enumerate() {

--- a/code/arcaders-1-12/Cargo.toml
+++ b/code/arcaders-1-12/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
 rand = "0.3"
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_ttf = "0.24"

--- a/code/arcaders-1-12/src/phi/data.rs
+++ b/code/arcaders-1-12/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
         // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
     /// Generate a rectangle with the provided size, with its top-left corner

--- a/code/arcaders-1-12/src/phi/gfx.rs
+++ b/code/arcaders-1-12/src/phi/gfx.rs
@@ -75,7 +75,7 @@ impl Sprite {
 
 impl Renderable for Sprite {
     fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-12/src/phi/mod.rs
+++ b/code/arcaders-1-12/src/phi/mod.rs
@@ -6,6 +6,7 @@ pub mod gfx;
 use self::gfx::Sprite;
 use sdl2::render::Renderer;
 use sdl2::pixels::Color;
+use sdl2_ttf::Sdl2TtfContext;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -36,6 +37,7 @@ pub struct Phi<'window> {
     pub events: Events,
     pub renderer: Renderer<'window>,
 
+    ttf_context: Sdl2TtfContext,
     cached_fonts: HashMap<(&'static str, i32), ::sdl2_ttf::Font>,
 }
 
@@ -44,6 +46,7 @@ impl<'window> Phi<'window> {
         Phi {
             events: events,
             renderer: renderer,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
             cached_fonts: HashMap::new(),
         }
     }
@@ -57,12 +60,12 @@ impl<'window> Phi<'window> {
     /// Renders a string of text as a sprite using the provided parameters.
     pub fn ttf_str_sprite(&mut self, text: &str, font_path: &'static str, size: i32, color: Color) -> Option<Sprite> {
         if let Some(font) = self.cached_fonts.get(&(font_path, size)) {
-            return font.render(text, ::sdl2_ttf::blended(color)).ok()
+            return font.render(text).blended(color).ok()
                 .and_then(|surface| self.renderer.create_texture_from_surface(&surface).ok())
                 .map(Sprite::new)
         }
 
-        ::sdl2_ttf::Font::from_file(Path::new(font_path), size).ok()
+        self.ttf_context.load_font(Path::new(font_path), size as u16).ok()
             .and_then(|font| {
                 self.cached_fonts.insert((font_path, size), font);
                 self.ttf_str_sprite(text, font_path, size, color)
@@ -126,7 +129,6 @@ where F: Fn(&mut Phi) -> Box<View> {
     let video = sdl_context.video().unwrap();
     let mut timer = sdl_context.timer().unwrap();
     let _image_context = ::sdl2_image::init(::sdl2_image::INIT_PNG).unwrap();
-    let _ttf_context = ::sdl2_ttf::init().unwrap();
 
     // Create the window
     let window = video.window(title, 800, 600)

--- a/code/arcaders-1-12/src/views/bullets.rs
+++ b/code/arcaders-1-12/src/views/bullets.rs
@@ -44,7 +44,7 @@ impl Bullet for RectBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -79,7 +79,7 @@ impl Bullet for SineBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -124,7 +124,7 @@ impl Bullet for DivergentBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {

--- a/code/arcaders-1-12/src/views/game.rs
+++ b/code/arcaders-1-12/src/views/game.rs
@@ -163,7 +163,7 @@ impl Player {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the ship's current sprite.
@@ -217,7 +217,7 @@ impl Asteroid {
     fn render(&self, phi: &mut Phi) {
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+            phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
         }
 
         phi.renderer.copy_sprite(&self.sprite, self.rect);

--- a/code/arcaders-1-12/src/views/main_menu.rs
+++ b/code/arcaders-1-12/src/views/main_menu.rs
@@ -115,7 +115,8 @@ impl View for MainMenuView {
             h: box_h + border_width * 2.0 + margin_h * 2.0,
             x: (win_w - box_w) / 2.0 - border_width,
             y: (win_h - box_h) / 2.0 - margin_h - border_width,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the colored box which holds the labels
         phi.renderer.set_draw_color(Color::RGB(140, 30, 140));
@@ -124,7 +125,8 @@ impl View for MainMenuView {
             h: box_h + margin_h * 2.0,
             x: (win_w - box_w) / 2.0,
             y: (win_h - box_h) / 2.0 - margin_h,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the labels in the menu
         for (i, action) in self.actions.iter().enumerate() {

--- a/code/arcaders-1-13/Cargo.toml
+++ b/code/arcaders-1-13/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
 rand = "0.3"
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
-sdl2_mixer = "0.12"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_mixer = "0.24"
+sdl2_ttf = "0.24"

--- a/code/arcaders-1-13/src/phi/data.rs
+++ b/code/arcaders-1-13/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
         // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
     /// Generate a rectangle with the provided size, with its top-left corner

--- a/code/arcaders-1-13/src/phi/gfx.rs
+++ b/code/arcaders-1-13/src/phi/gfx.rs
@@ -75,7 +75,7 @@ impl Sprite {
 
 impl Renderable for Sprite {
     fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-13/src/views/bullets.rs
+++ b/code/arcaders-1-13/src/views/bullets.rs
@@ -44,7 +44,7 @@ impl Bullet for RectBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -79,7 +79,7 @@ impl Bullet for SineBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {
@@ -124,7 +124,7 @@ impl Bullet for DivergentBullet {
     fn render(&self, phi: &mut Phi) {
         // We will render this kind of bullet in yellow.
         phi.renderer.set_draw_color(Color::RGB(230, 230, 30));
-        phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+        phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
     }
 
     fn rect(&self) -> Rectangle {

--- a/code/arcaders-1-13/src/views/game.rs
+++ b/code/arcaders-1-13/src/views/game.rs
@@ -165,7 +165,7 @@ impl Player {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the ship's current sprite.
@@ -219,7 +219,7 @@ impl Asteroid {
     fn render(&self, phi: &mut Phi) {
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.rect().to_sdl().unwrap());
+            phi.renderer.fill_rect(self.rect().to_sdl().unwrap()).unwrap();
         }
 
         phi.renderer.copy_sprite(&self.sprite, self.rect);

--- a/code/arcaders-1-13/src/views/main_menu.rs
+++ b/code/arcaders-1-13/src/views/main_menu.rs
@@ -122,7 +122,8 @@ impl View for MainMenuView {
             h: box_h + border_width * 2.0 + margin_h * 2.0,
             x: (win_w - box_w) / 2.0 - border_width,
             y: (win_h - box_h) / 2.0 - margin_h - border_width,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the colored box which holds the labels
         phi.renderer.set_draw_color(Color::RGB(140, 30, 140));
@@ -131,7 +132,8 @@ impl View for MainMenuView {
             h: box_h + margin_h * 2.0,
             x: (win_w - box_w) / 2.0,
             y: (win_h - box_h) / 2.0 - margin_h,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the labels in the menu
         for (i, action) in self.actions.iter().enumerate() {

--- a/code/arcaders-1-2/Cargo.toml
+++ b/code/arcaders-1-2/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
+sdl2 = "0.24"

--- a/code/arcaders-1-3/Cargo.toml
+++ b/code/arcaders-1-3/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
+sdl2 = "0.24"

--- a/code/arcaders-1-4/Cargo.toml
+++ b/code/arcaders-1-4/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
+sdl2 = "0.24"

--- a/code/arcaders-1-5/Cargo.toml
+++ b/code/arcaders-1-5/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
+sdl2 = "0.24"

--- a/code/arcaders-1-6/Cargo.toml
+++ b/code/arcaders-1-6/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
+sdl2 = "0.24"

--- a/code/arcaders-1-6/src/phi/data.rs
+++ b/code/arcaders-1-6/src/phi/data.rs
@@ -17,9 +17,7 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
     /// Return a (perhaps moved) rectangle which is contained by a `parent`

--- a/code/arcaders-1-6/src/views/mod.rs
+++ b/code/arcaders-1-6/src/views/mod.rs
@@ -86,7 +86,7 @@ impl View for ShipView {
 
         // Render the scene
         phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-        phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
 
 
         ViewAction::None

--- a/code/arcaders-1-7/Cargo.toml
+++ b/code/arcaders-1-7/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
+sdl2 = "0.24"
+sdl2_image = "0.24"

--- a/code/arcaders-1-7/src/phi/data.rs
+++ b/code/arcaders-1-7/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
-        // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        // Will panic if the width or the height is negative.
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
 

--- a/code/arcaders-1-7/src/phi/gfx.rs
+++ b/code/arcaders-1-7/src/phi/gfx.rs
@@ -65,7 +65,7 @@ impl Sprite {
 
 
     pub fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-7/src/views/mod.rs
+++ b/code/arcaders-1-7/src/views/mod.rs
@@ -138,7 +138,7 @@ impl View for ShipView {
 
         // Render the bounding box (for debugging purposes)
         phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-        phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+        phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
 
         // Render the ship
         phi.renderer.copy_sprite(

--- a/code/arcaders-1-8/Cargo.toml
+++ b/code/arcaders-1-8/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
+sdl2 = "0.24"
+sdl2_image = "0.24"

--- a/code/arcaders-1-8/src/phi/data.rs
+++ b/code/arcaders-1-8/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
         // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
 

--- a/code/arcaders-1-8/src/phi/gfx.rs
+++ b/code/arcaders-1-8/src/phi/gfx.rs
@@ -65,7 +65,7 @@ impl Sprite {
 
 
     pub fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-8/src/views/mod.rs
+++ b/code/arcaders-1-8/src/views/mod.rs
@@ -206,7 +206,7 @@ impl View for ShipView {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the ship

--- a/code/arcaders-1-9/Cargo.toml
+++ b/code/arcaders-1-9/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["John Doe <john.doe@example.com>"]
 
 [dependencies]
-sdl2 = "0.13"
-sdl2_image = "1.0.0"
-sdl2_ttf = "0.13.1"
+sdl2 = "0.24"
+sdl2_image = "0.24"
+sdl2_ttf = "0.24"

--- a/code/arcaders-1-9/src/phi/data.rs
+++ b/code/arcaders-1-9/src/phi/data.rs
@@ -17,10 +17,8 @@ impl Rectangle {
         // Reject negative width and height
         assert!(self.w >= 0.0 && self.h >= 0.0);
 
-        // SdlRect::new : `(i32, i32, u32, u32) -> Result<Option<SdlRect>>`
         // Will panic if the width of the height is negative.
-        SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32)
-            .unwrap()
+        Some(SdlRect::new(self.x as i32, self.y as i32, self.w as u32, self.h as u32))
     }
 
 

--- a/code/arcaders-1-9/src/phi/gfx.rs
+++ b/code/arcaders-1-9/src/phi/gfx.rs
@@ -65,7 +65,7 @@ impl Sprite {
 
 
     pub fn render(&self, renderer: &mut Renderer, dest: Rectangle) {
-        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl())
+        renderer.copy(&mut self.tex.borrow_mut(), self.src.to_sdl(), dest.to_sdl()).unwrap()
     }
 }
 

--- a/code/arcaders-1-9/src/phi/mod.rs
+++ b/code/arcaders-1-9/src/phi/mod.rs
@@ -6,6 +6,7 @@ pub mod gfx;
 use self::gfx::Sprite;
 use sdl2::render::Renderer;
 use sdl2::pixels::Color;
+use sdl2_ttf::Sdl2TtfContext;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -32,6 +33,7 @@ pub struct Phi<'window> {
     pub events: Events,
     pub renderer: Renderer<'window>,
 
+    ttf_context: Sdl2TtfContext,
     cached_fonts: HashMap<(&'static str, i32), ::sdl2_ttf::Font>,
 }
 
@@ -40,6 +42,7 @@ impl<'window> Phi<'window> {
         Phi {
             events: events,
             renderer: renderer,
+            ttf_context: ::sdl2_ttf::init().unwrap(),
             cached_fonts: HashMap::new(),
         }
     }
@@ -53,12 +56,12 @@ impl<'window> Phi<'window> {
     /// Renders a string of text as a sprite using the provided parameters.
     pub fn ttf_str_sprite(&mut self, text: &str, font_path: &'static str, size: i32, color: Color) -> Option<Sprite> {
         if let Some(font) = self.cached_fonts.get(&(font_path, size)) {
-            return font.render(text, ::sdl2_ttf::blended(color)).ok()
+            return font.render(text).blended(color).ok()
                 .and_then(|surface| self.renderer.create_texture_from_surface(&surface).ok())
                 .map(Sprite::new)
         }
 
-        ::sdl2_ttf::Font::from_file(Path::new(font_path), size).ok()
+        self.ttf_context.load_font(Path::new(font_path), size as u16).ok()
             .and_then(|font| {
                 self.cached_fonts.insert((font_path, size), font);
                 self.ttf_str_sprite(text, font_path, size, color)
@@ -122,7 +125,6 @@ where F: Fn(&mut Phi) -> Box<View> {
     let video = sdl_context.video().unwrap();
     let mut timer = sdl_context.timer().unwrap();
     let _image_context = ::sdl2_image::init(::sdl2_image::INIT_PNG).unwrap();
-    let _ttf_context = ::sdl2_ttf::init().unwrap();
 
     // Create the window
     let window = video.window(title, 800, 600)

--- a/code/arcaders-1-9/src/views/game.rs
+++ b/code/arcaders-1-9/src/views/game.rs
@@ -164,7 +164,7 @@ impl View for ShipView {
         // Render the bounding box (for debugging purposes)
         if DEBUG {
             phi.renderer.set_draw_color(Color::RGB(200, 200, 50));
-            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap());
+            phi.renderer.fill_rect(self.player.rect.to_sdl().unwrap()).unwrap();
         }
 
         // Render the ship

--- a/code/arcaders-1-9/src/views/main_menu.rs
+++ b/code/arcaders-1-9/src/views/main_menu.rs
@@ -115,7 +115,8 @@ impl View for MainMenuView {
             h: box_h + border_width * 2.0 + margin_h * 2.0,
             x: (win_w - box_w) / 2.0 - border_width,
             y: (win_h - box_h) / 2.0 - margin_h - border_width,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the colored box which holds the labels
         phi.renderer.set_draw_color(Color::RGB(140, 30, 140));
@@ -124,7 +125,8 @@ impl View for MainMenuView {
             h: box_h + margin_h * 2.0,
             x: (win_w - box_w) / 2.0,
             y: (win_h - box_h) / 2.0 - margin_h,
-        }.to_sdl().unwrap());
+        }.to_sdl().unwrap())
+        .unwrap();
 
         // Render the labels in the menu
         for (i, action) in self.actions.iter().enumerate() {


### PR DESCRIPTION
Some API changes implied modifications in the code:
- Most sdl2 Renderer drawing methods return Result\<(), String\>
  and need to be unwrapped
- sdl2 Rect::new no longer returns Result\<Option\<Rect\>\> but
  directly Rect.
- sdl2_ttf font loading needs to be done from the ttf context,
  currently worked around by adding it to Phi.

Note: WIP, only reviewed code and articles up to chapter 10.

---

I plan to continue working my way through the tutorials to adapt them all to the 0.24 libraries, but as I am pretty new to Rust, I'd be glad to have some feedback on the solutions I chose to integrate the API changes.
