### PR TITLE
ArcadeRS: Add .gitignores to all code snapshots

### DIFF
--- a/code/arcaders-1-1/.gitignore
+++ b/code/arcaders-1-1/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-10/.gitignore
+++ b/code/arcaders-1-10/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-11/.gitignore
+++ b/code/arcaders-1-11/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-12-preclean/.gitignore
+++ b/code/arcaders-1-12-preclean/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-12/.gitignore
+++ b/code/arcaders-1-12/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-13/.gitignore
+++ b/code/arcaders-1-13/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-2/.gitignore
+++ b/code/arcaders-1-2/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-3/.gitignore
+++ b/code/arcaders-1-3/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-4/.gitignore
+++ b/code/arcaders-1-4/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-5/.gitignore
+++ b/code/arcaders-1-5/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-6/.gitignore
+++ b/code/arcaders-1-6/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-7/.gitignore
+++ b/code/arcaders-1-7/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-8/.gitignore
+++ b/code/arcaders-1-8/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/code/arcaders-1-9/.gitignore
+++ b/code/arcaders-1-9/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/


### PR DESCRIPTION
This avoid mistakenly versioning Cargo.lock or target/ when doing
fixes in the code snapshots.
