### PR TITLE
arcaders: Adapt trait clone error for rust 1.12.1

### DIFF
--- a/_posts/2016-01-03-arcaders-1-11.md
+++ b/_posts/2016-01-03-arcaders-1-11.md
@@ -591,7 +591,7 @@ vehemently protest by printing a wall of error messages that don't make much
 sense, for example,
 
 ```
-error: the trait `views::game::Bullet` is not implemented for the type `views::game::Bullet` [E0277]
+error[E0038]: the trait `views::game::Bullet` cannot be made into an object
 ```
 
 Moral of the story: if you see such confusing error messages, you are probably


### PR DESCRIPTION
The following explanations about the error message being confusing
might need some adjusting, now that it is somewhat less confusing.